### PR TITLE
Fix missing 'enableWatchFeedEntrypoint' parameter in get_playlist_info method

### DIFF
--- a/spotapi/playlist.py
+++ b/spotapi/playlist.py
@@ -48,7 +48,7 @@ class PublicPlaylist:
         self.playlist_link = f"https://open.spotify.com/playlist/{self.playlist_id}"
 
     def get_playlist_info(
-        self, limit: int = 25, *, offset: int = 0
+        self, limit: int = 25, *, offset: int = 0, enable_watch_feed_entrypoint: bool = False
     ) -> Mapping[str, Any]:
         """Gets the public playlist information"""
         url = "https://api-partner.spotify.com/pathfinder/v1/query"
@@ -59,6 +59,7 @@ class PublicPlaylist:
                     "uri": f"spotify:playlist:{self.playlist_id}",
                     "offset": offset,
                     "limit": limit,
+                    "enableWatchFeedEntrypoint": enable_watch_feed_entrypoint,
                 }
             ),
             "extensions": json.dumps(


### PR DESCRIPTION
### Problem
The `get_playlist_info` method was causing a `ValidationError` due to a missing 'enableWatchFeedEntrypoint' parameter.
Fixes #14

### Solution
- Added the parameter 'enableWatchFeedEntrypoint' with a default value (False).
- Updated the API request to include this parameter.
- Tested locally and verified the API returns expected results.

### Impact
No breaking changes; the fix ensures the method works as intended.