### PR TITLE
create mkdocs documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+uv.lock
 
 # Spyder project settings
 .spyderproject

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,0 +1,16 @@
+nav:
+  - index.md
+  - installation.md
+  - album.md
+  - artist.md
+  - creator.md
+  - family.md
+  - login.md
+  - password.md
+  - player.md
+  - playlist.md
+  - public.md
+  - song.md
+  - status.md
+  - user.md
+  - websocket.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# Welcome to SpotAPI
+
+This Python library is designed to interact with the private and public Spotify APIs, emulating the requests typically made through a web browser. This wrapper provides a convenient way to access Spotify’s rich set of features programmatically.
+
+Note: This project is intended solely for educational purposes and should be used responsibly. Accessing private endpoints and scraping data without proper authorization may violate Spotify's terms of service.
+
+## Features
+
+- No Premium Required: Unlike the Web API which requires Spotify Premium, SpotAPI requires no Spotify Premium at all!
+- Public API Access: Retrieve and manipulate public Spotify data such as playlists, albums, and tracks with ease.
+- Private API Access: Explore private Spotify endpoints to tailor your application to your needs.
+- Ready to Use: SpotAPI is designed for immediate integration, allowing you to accomplish tasks with just a few lines of code.
+- No API Key Required: Seamlessly use SpotAPI without needing a Spotify API key. It’s straightforward and hassle free!
+- Browser-like Requests: Accurately replicate the HTTP requests Spotify makes in the browser, providing a true to web experience while remaining undetected.
+- Everything you can do with Spotify, SpotAPI can do with just a user’s login credentials.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,73 @@
+## Installation
+
+```
+pip install spotapi
+```
+
+## Quick Examples
+
+### With User Authentication
+
+```py
+from spotapi import (
+    Login,
+    Config,
+    NoopLogger,
+    solver_clients,
+    PrivatePlaylist,
+    MongoSaver
+)
+
+cfg = Config(
+    solver=solver_clients.Capsolver("YOUR_API_KEY", proxy="YOUR_PROXY"), # Proxy is optional
+    logger=NoopLogger(),
+    # You can add a proxy by passing a custom TLSClient
+)
+
+instance = Login(cfg, "YOUR_PASSWORD", email="YOUR_EMAIL")
+# Now we have a valid Login instance to pass around
+instance.login()
+
+# Do whatever you want now
+playlist = PrivatePlaylist(instance)
+playlist.create_playlist("SpotAPI Showcase!")
+
+# Save the session
+instance.save(MongoSaver())
+```
+
+### Without User Authentication
+
+```py
+"""Here's the example from spotipy https://github.com/spotipy-dev/spotipy?tab=readme-ov-file#quick-start"""
+from spotapi import Song
+
+song = Song()
+gen = song.paginate_songs("weezer")
+
+# Paginates 100 songs at a time till there's no more
+for batch in gen:
+    for idx, item in enumerate(batch):
+        print(idx, item['item']['data']['name'])
+
+# ^ ONLY 6 LINES OF CODE
+
+# Alternatively, you can query a specfic amount
+songs = song.query_songs("weezer", limit=20)
+data = songs["data"]["searchV2"]["tracksV2"]["items"]
+for idx, item in enumerate(data):
+    print(idx, item['item']['data']['name'])
+```
+
+### Results
+
+```
+0 Island In The Sun
+1 Say It Ain't So
+2 Buddy Holly
+.
+.
+.
+18 Holiday
+19 We Are All On d***s
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,37 @@
+site_name: SpotAPI
+site_url: https://mydomain.org/spotapi
+repo_url: https://github.com/Aran404/SpotAPI
+repo_name: Aran404/SpotAPI
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.top
+    - navigation.tracking
+    - navigation.sections
+    - navigation.instant
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      pygments_lang_class: true
+      auto_title: true
+      line_spans: __span
+  - pymdownx.keys
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+plugins:
+  - search
+  - awesome-nav

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "spotapi"
+version = "0.1.0"
+description = "A python wrapper for the public & private Spotify API"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+  "colorama>=0.4.6",
+  "mkdocs-awesome-nav>=3.0.0",
+  "mkdocs-material>=9.6.9",
+  "pillow>=11.1.0",
+  "readerwriterlock>=1.0.9",
+  "requests>=2.32.3",
+  "tls-client>=1.0.1",
+  "typing-extensions>=4.12.2",
+  "validators>=0.34.0",
+  "websockets>=15.0.1",
+]


### PR DESCRIPTION
Ive created basic documentation in MkDocs. The website is not created yet, but you can see the result if you run `mkdocs serve` and open the live server.

If you like it, I can then build the website. 

Ive created a pyproject.toml too, which is the new standard for dependences.

Preview:

<img width="1721" alt="image" src="https://github.com/user-attachments/assets/bee6597c-4e4b-48ad-a824-0f46c79d81b2" />
