### PR TITLE
Fix: Specify domain when setting cookies to prevent conflicts

### DIFF
--- a/spotapi/login.py
+++ b/spotapi/login.py
@@ -115,7 +115,7 @@ class Login:
 
         cfg.client.cookies.clear()
         for k, v in cookies.items():
-            cfg.client.cookies.set(k, v)
+            cfg.client.cookies.set(k, v, domain=".spotify.com", path="/")
 
         instantiated = cls(cfg, password, email=cred, username=cred)
         instantiated.logged_in = True


### PR DESCRIPTION
## Problem
The application was encountering a `CookieConflictError` when trying to access cookies:

tls_client.cookies.CookieConflictError: There are multiple cookies with name, 'sp_t'

This error occurred because cookies were being set without specifying a domain initially, and later the same cookie name (`sp_t`) was set with the `.spotify.com` domain, resulting in duplicate cookies with the same name but different domains.

## Solution
Modified the `from_cookies` method in `spotapi/login.py` to explicitly specify the domain when setting cookies:

```python
# Before
cfg.client.cookies.set(k, v)

# After  
cfg.client.cookies.set(k, v, domain=".spotify.com", path="/")
```

## Changes
- Updated line 118 in `spotapi/login.py` to include explicit domain specification
- Ensures all cookies are consistently set with the same domain
- Prevents cookie conflicts when the same cookie name is used

## Testing
- [x] Verified that the CookieConflictError no longer occurs
- [x] Confirmed that login functionality works as expected
- [x] Tested cookie restoration from saved sessions

This fix ensures consistent cookie handling and prevents the duplicate cookie name conflicts that were causing authentication failures.