### PR TITLE
Fix payload variable name in add_song_to_playlist method

### DIFF
--- a/spotapi/song.py
+++ b/spotapi/song.py
@@ -275,7 +275,7 @@ class Song:
 
         url = "https://api-partner.spotify.com/pathfinder/v1/query"
         payload = {
-            "variables": {"uris": [f"spotify:track:{song_id}"]},
+            "variables": {"libraryItemUris": [f"spotify:track:{song_id}"]},
             "operationName": "addToLibrary",
             "extensions": {
                 "persistedQuery": {


### PR DESCRIPTION
Updated payload variable to fix spotapi.exceptions.errors.SongError: Could not like song.