### PR TITLE
Refresh access_token and client_token on expiry and auth failure

### DIFF
--- a/spotapi/_tests/client_refresh_test.py
+++ b/spotapi/_tests/client_refresh_test.py
@@ -1,0 +1,223 @@
+# type: ignore
+"""Unit tests for the hybrid token refresh flow in BaseClient / TLSClient.
+
+These tests do not hit the network: the HTTP layer is patched so the
+refresh/retry decision logic can be exercised in isolation.
+"""
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from spotapi.client import BaseClient
+from spotapi.http.data import Response
+from spotapi.http.request import TLSClient
+from spotapi.types.alias import _Undefined
+
+
+def _make_base():
+    """A BaseClient whose init-time network methods are stubbed out."""
+    client = TLSClient("chrome_120", "", auto_retries=1)
+    base = BaseClient(client=client)
+    # Pre-populate so _auth_rule does not fall into the first-time init branches
+    base.client_token = "ct"
+    base.access_token = "at"
+    base.client_id = "cid"
+    base.client_version = "1.0.0"
+    base.device_id = "did"
+    base.access_token_expires_at_ms = (time.time() + 600) * 1000  # 10 min out
+    return base
+
+
+def _make_tls_response(status_code, headers=None, text=""):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.headers = headers or {}
+    mock.text = text
+    mock.url = "https://example.com/x"
+    mock.json.return_value = None
+    return mock
+
+
+def _make_response(status_code, headers=None):
+    raw = _make_tls_response(status_code, headers=headers)
+    return Response(raw=raw, status_code=status_code, response=None)
+
+
+# ---------- _auth_rule proactive refresh ----------
+
+
+def test_proactive_refresh_fires_when_near_expiry():
+    base = _make_base()
+    base.access_token_expires_at_ms = (time.time() + 1) * 1000  # inside skew window
+    calls = []
+    base._get_auth_vars = lambda: calls.append("called")
+
+    base._auth_rule({})
+
+    assert calls == ["called"]
+
+
+def test_proactive_refresh_skipped_when_fresh():
+    base = _make_base()  # expiry is 10 min out
+    calls = []
+    base._get_auth_vars = lambda: calls.append("called")
+
+    base._auth_rule({})
+
+    assert calls == []
+
+
+def test_auth_rule_sets_expected_headers():
+    base = _make_base()
+    kwargs = base._auth_rule({})
+
+    headers = kwargs["headers"]
+    assert headers["Authorization"] == "Bearer at"
+    assert headers["Client-Token"] == "ct"
+    assert headers["Spotify-App-Version"] == "1.0.0"
+
+
+# ---------- _handle_auth_failure ----------
+
+
+def test_handle_401_refreshes_access_token():
+    base = _make_base()
+    calls = []
+
+    def fake_refresh():
+        calls.append("called")
+        base.access_token = "new_at"
+
+    base._get_auth_vars = fake_refresh
+    base.access_token = _Undefined  # simulate reset-before-refresh
+
+    retried = base._handle_auth_failure(_make_response(401))
+
+    assert retried is True
+    assert calls == ["called"]
+
+
+def test_handle_401_resets_access_token_before_refresh():
+    base = _make_base()
+    seen = []
+    base._get_auth_vars = lambda: seen.append(base.access_token)
+
+    base._handle_auth_failure(_make_response(401))
+
+    assert seen == [_Undefined], "access_token must be reset before _get_auth_vars runs"
+
+
+def test_handle_400_with_client_token_error_refreshes_client_token():
+    base = _make_base()
+    calls = []
+
+    def fake_refresh():
+        calls.append("called")
+        base.client_token = "new_ct"
+
+    base.get_client_token = fake_refresh
+
+    retried = base._handle_auth_failure(
+        _make_response(400, headers={"Client-Token-Error": "INVALID_CLIENTTOKEN"})
+    )
+
+    assert retried is True
+    assert calls == ["called"]
+
+
+def test_handle_400_without_client_token_error_returns_false():
+    base = _make_base()
+    base.get_client_token = lambda: pytest.fail("should not refresh")
+    base._get_auth_vars = lambda: pytest.fail("should not refresh")
+
+    retried = base._handle_auth_failure(_make_response(400))
+
+    assert retried is False
+
+
+def test_handle_500_returns_false():
+    base = _make_base()
+    base.get_client_token = lambda: pytest.fail("should not refresh")
+    base._get_auth_vars = lambda: pytest.fail("should not refresh")
+
+    retried = base._handle_auth_failure(_make_response(500))
+
+    assert retried is False
+
+
+def test_handle_200_returns_false():
+    base = _make_base()
+    retried = base._handle_auth_failure(_make_response(200))
+    assert retried is False
+
+
+# ---------- TLSClient._send retry-once ----------
+
+
+def _patch_send(client, responses):
+    """Make build_request return the given TLS responses in sequence."""
+    it = iter(responses)
+    client.build_request = lambda *args, **kwargs: next(it)
+
+
+def test_send_retries_once_on_auth_failure():
+    client = TLSClient("chrome_120", "", auto_retries=1)
+    _patch_send(
+        client,
+        [
+            _make_tls_response(401, headers={"Www-Authenticate": "Bearer"}),
+            _make_tls_response(200),
+        ],
+    )
+
+    auth_calls = []
+    client.authenticate = lambda kwargs: (auth_calls.append(1) or kwargs)
+    client.on_auth_failure = lambda resp: True
+
+    resp = client.get("https://example.com/x", authenticate=True)
+
+    assert resp.status_code == 200
+    assert len(auth_calls) == 2, "authenticate should run once per attempt"
+
+
+def test_send_does_not_retry_when_handler_returns_false():
+    client = TLSClient("chrome_120", "", auto_retries=1)
+    _patch_send(client, [_make_tls_response(500)])
+
+    client.authenticate = lambda kwargs: kwargs
+    client.on_auth_failure = lambda resp: False
+
+    resp = client.get("https://example.com/x", authenticate=True)
+
+    assert resp.status_code == 500
+
+
+def test_send_does_not_retry_without_authenticate_flag():
+    client = TLSClient("chrome_120", "", auto_retries=1)
+    _patch_send(client, [_make_tls_response(401)])
+
+    client.authenticate = lambda kwargs: kwargs
+    client.on_auth_failure = lambda resp: pytest.fail("should not be called")
+
+    resp = client.get("https://example.com/x", authenticate=False)
+
+    assert resp.status_code == 401
+
+
+def test_send_retries_at_most_once_even_if_second_attempt_also_fails():
+    client = TLSClient("chrome_120", "", auto_retries=1)
+    # If _send retried more than once, StopIteration would fire
+    _patch_send(
+        client,
+        [_make_tls_response(401), _make_tls_response(401)],
+    )
+
+    client.authenticate = lambda kwargs: kwargs
+    handler_calls = []
+    client.on_auth_failure = lambda resp: (handler_calls.append(1) or True)
+
+    resp = client.get("https://example.com/x", authenticate=True)
+
+    assert resp.status_code == 401
+    assert len(handler_calls) == 1, "on_auth_failure must only be consulted once"

--- a/spotapi/client.py
+++ b/spotapi/client.py
@@ -10,6 +10,7 @@ from spotapi.utils.logger import Logger
 from spotapi.types.annotations import enforce
 from spotapi.types.alias import _UStr, _Undefined
 from spotapi.exceptions import BaseClientError
+from spotapi.http.data import Response
 from spotapi.http.request import TLSClient
 from spotapi.utils.strings import extract_js_links, extract_mappings, combine_chunks
 
@@ -76,16 +77,21 @@ class BaseClient:
     js_pack: _UStr = _Undefined
     client_version: _UStr = _Undefined
     access_token: _UStr = _Undefined
+    access_token_expires_at_ms: float = 0
     client_token: _UStr = _Undefined
     client_id: _UStr = _Undefined
     device_id: _UStr = _Undefined
     raw_hashes: _UStr = _Undefined
     language: str = "en"
 
+    # Refresh a bit before real expiry to avoid skew-induced 401s
+    _REFRESH_SKEW_MS: float = 30_000
+
     def __init__(self, client: TLSClient, language: str = "en") -> None:
         self.client = client
         self.language = language
         self.client.authenticate = lambda kwargs: self._auth_rule(kwargs)
+        self.client.on_auth_failure = lambda resp: self._handle_auth_failure(resp)
 
         self.browser_version = self.client.client_identifier.split("_")[1]
         self.client.headers.update(
@@ -105,6 +111,14 @@ class BaseClient:
         if self.access_token is _Undefined:
             self.get_session()
 
+        if (
+            self.access_token_expires_at_ms
+            and time.time() * 1000 + self._REFRESH_SKEW_MS
+            >= self.access_token_expires_at_ms
+        ):
+            self.access_token = _Undefined
+            self._get_auth_vars()
+
         if "headers" not in kwargs:
             kwargs["headers"] = {}
 
@@ -118,6 +132,24 @@ class BaseClient:
         )
 
         return kwargs
+
+    def _handle_auth_failure(self, resp: Response) -> bool:
+        if resp.status_code == 401:
+            self.access_token = _Undefined
+            self._get_auth_vars()
+            return True
+
+        if resp.status_code == 400:
+            try:
+                headers = {k.lower(): v for k, v in resp.raw.headers.items()}
+            except Exception:
+                headers = {}
+            if headers.get("client-token-error") == "INVALID_CLIENTTOKEN":
+                self.client_token = _Undefined
+                self.get_client_token()
+                return True
+
+        return False
 
     def set_language(self, language: str) -> None:
         """Set the language for API requests. Uses ISO 639-1 language codes (e.g., 'ko', 'en', 'ja')."""
@@ -143,6 +175,9 @@ class BaseClient:
 
             self.access_token = resp.response["accessToken"]
             self.client_id = resp.response["clientId"]
+            self.access_token_expires_at_ms = float(
+                resp.response.get("accessTokenExpirationTimestampMs") or 0
+            )
 
     def get_session(self) -> None:
         resp = self.client.get("https://open.spotify.com")

--- a/spotapi/http/request.py
+++ b/spotapi/http/request.py
@@ -130,6 +130,7 @@ class TLSClient(Session):
 
         self.auto_retries = auto_retries + 1
         self.authenticate = auth_rule
+        self.on_auth_failure: Callable[[Response], bool] | None = None
         self.fail_exception: Type[ParentException] | None = None
         atexit.register(self.close)
 
@@ -195,19 +196,50 @@ class TLSClient(Session):
 
         return resp
 
+    def _send(
+        self,
+        method: str,
+        url: str | bytes,
+        *,
+        authenticate: bool,
+        danger: bool,
+        **kwargs,
+    ) -> Response:
+        if authenticate and self.authenticate is not None:
+            kwargs = self.authenticate(kwargs)
+
+        response = self.build_request(method, url, allow_redirects=True, **kwargs)
+        if response is None:
+            raise TLSClientExeption("Request kept failing after retries.")
+
+        parsed = self.parse_response(response, method, False)
+
+        if (
+            authenticate
+            and self.on_auth_failure is not None
+            and self.authenticate is not None
+            and parsed.fail
+            and self.on_auth_failure(parsed)
+        ):
+            kwargs = self.authenticate(kwargs)
+            response = self.build_request(method, url, allow_redirects=True, **kwargs)
+            if response is None:
+                raise TLSClientExeption("Request kept failing after retries.")
+            parsed = self.parse_response(response, method, False)
+
+        if danger and self.fail_exception and parsed.fail:
+            raise self.fail_exception(
+                f"Could not {method} {str(response.url).split('?')[0]}. Status Code: {parsed.status_code}",
+                "Request Failed.",
+            )
+
+        return parsed
+
     def get(
         self, url: str | bytes, *, authenticate: bool = False, **kwargs
     ) -> Response:
         """Routes a GET Request"""
-        if authenticate and self.authenticate is not None:
-            kwargs = self.authenticate(kwargs)
-
-        response = self.build_request("GET", url, allow_redirects=True, **kwargs)
-
-        if response is None:
-            raise TLSClientExeption("Request kept failing after retries.")
-
-        return self.parse_response(response, "GET", True)
+        return self._send("GET", url, authenticate=authenticate, danger=True, **kwargs)
 
     def post(
         self,
@@ -218,15 +250,9 @@ class TLSClient(Session):
         **kwargs,
     ) -> Response:
         """Routes a POST Request"""
-        if authenticate and self.authenticate is not None:
-            kwargs = self.authenticate(kwargs)
-
-        response = self.build_request("POST", url, allow_redirects=True, **kwargs)
-
-        if response is None:
-            raise TLSClientExeption("Request kept failing after retries.")
-
-        return self.parse_response(response, "POST", danger)
+        return self._send(
+            "POST", url, authenticate=authenticate, danger=danger, **kwargs
+        )
 
     def put(
         self,
@@ -237,12 +263,6 @@ class TLSClient(Session):
         **kwargs,
     ) -> Response:
         """Routes a PUT Request"""
-        if authenticate and self.authenticate is not None:
-            kwargs = self.authenticate(kwargs)
-
-        response = self.build_request("PUT", url, allow_redirects=True, **kwargs)
-
-        if response is None:
-            raise TLSClientExeption("Request kept failing after retries.")
-
-        return self.parse_response(response, "PUT", danger)
+        return self._send(
+            "PUT", url, authenticate=authenticate, danger=danger, **kwargs
+        )


### PR DESCRIPTION
## Summary

Adds automatic refresh for `access_token` and `client_token` so long-running processes don't break when tokens expire. Previously `BaseClient` fetched tokens once at init and reused them until the process ended — Spotify's web tokens have a ~5 minute TTL in practice, so requests started failing silently after that window.

## What changed

- **Proactive refresh (`access_token`)** — `_get_auth_vars` now stores `accessTokenExpirationTimestampMs` from the `/api/token` response, and `_auth_rule` refreshes the token before sending if it's within a 30s skew buffer of expiry. No JWT decoding needed since the endpoint returns the expiry explicitly.
- **Reactive refresh (both tokens)** — `TLSClient` exposes a new `on_auth_failure` hook. `BaseClient` wires a handler that distinguishes the two failure modes Spotify actually returns:
  - `401` with `WWW-Authenticate: Bearer ... error="invalid_token"` → refresh `access_token`
  - `400` with `Client-Token-Error: INVALID_CLIENTTOKEN` → refresh `client_token`
- **Retry semantics** — `TLSClient.get/post/put` were consolidated into a `_send` helper that retries at most once on auth failure. The hook is consulted once per request, so there's no infinite-loop risk if the second attempt also fails.

## Backward compatibility

No public API changes. Existing call sites that use `authenticate=True` automatically benefit — no feature file (`artist.py`, `playlist.py`, etc.) was touched.

## Verification

- **End-to-end against live Spotify** — verified that corrupting `access_token` produces `401` and auto-recovers, corrupting `client_token` produces `400 / INVALID_CLIENTTOKEN` and auto-recovers, and poisoning `access_token_expires_at_ms` triggers proactive refresh before the request.
- **Unit tests** — added `spotapi/_tests/client_refresh_test.py` (13 cases) covering proactive refresh firing/skipping, `_handle_auth_failure` branching for 401 / 400+header / 400-other / 500 / 200, and `TLSClient._send` retry-once semantics. Tests mock the HTTP layer so they run without network or credentials.

## Test plan

- [x] `python -m pytest spotapi/_tests/client_refresh_test.py` — 13 passed
- [x] Live verification against `api-partner.spotify.com/pathfinder/v1/query` with corrupted tokens and poisoned expiry
