### PR TITLE
get_saved_tracks

### DIFF
--- a/docs/playlist.md
+++ b/docs/playlist.md
@@ -111,6 +111,31 @@ Deletes the playlist from the user's library. This is the same as removing it fr
   `ValueError` if the playlist ID is not set.  
   `PlaylistError` if there is an issue deleting the playlist.
 
+### `get_saved_tracks_info(self, limit: int = 25, *, offset: int = 0) -> Mapping[str, Any]`
+Fetches information about the user's Liked Songs.
+
+- **Args:**
+  - `limit`: `int`  
+    The maximum number of results to return. Default is 25.
+  - `offset`: `int`  
+    The offset for pagination. Default is 0.
+
+- **Returns:**  
+  `Mapping[str, Any]`  
+  The saved tracks information.
+
+- **Raises:**  
+  `PlaylistError` if there is an issue retrieving the playlist information or if the response is invalid.
+
+### `paginate_saved_tracks(self) -> Generator[Mapping[str, Any], None, None]`
+Generator that fetches Liked Songs information in chunks.
+
+- **Returns:**  
+  `Generator[Mapping[str, Any], None, None]`  
+  A generator yielding playlist information in chunks.
+
+- **Note:** If the total number of tracks is 343 or fewer, pagination is not required.
+
 ### `get_library(self, limit: int = 50, /) -> Mapping[str, Any]`
 Fetches all playlists in the user's library.
 

--- a/spotapi/playlist.py
+++ b/spotapi/playlist.py
@@ -277,6 +277,63 @@ class PrivatePlaylist:
 
         return resp.response
 
+    def get_saved_tracks_info(
+        self,
+        limit: int = 25,
+        *,
+        offset: int = 0,
+    ) -> Mapping[str, Any]:
+        """Gets the playlist information of saved songs"""
+        url = "https://api-partner.spotify.com/pathfinder/v1/query"
+        params = {
+            "operationName": "fetchLibraryTracks",
+            "variables": json.dumps(
+                {
+                    "offset": offset,
+                    "limit": limit,
+                }
+            ),
+            "extensions": json.dumps(
+                {
+                    "persistedQuery": {
+                        "version": 1,
+                        "sha256Hash": self.base.part_hash("fetchLibraryTracks"),
+                    }
+                }
+            ),
+        }
+
+        resp = self.login.client.post(url, params=params, authenticate=True)
+
+        if resp.fail:
+            raise PlaylistError("Could not get library tracks info", error=resp.error.string)
+
+        if not isinstance(resp.response, Mapping):
+            raise PlaylistError("Invalid JSON")
+
+        return resp.response
+
+    def paginate_saved_tracks(self) -> Generator[Mapping[str, Any], None, None]:
+        """
+        Generator that fetches playlist information in chunks
+
+        NOTE: If total_tracks <= 343, then there is no need to paginate.
+        """
+        UPPER_LIMIT: int = 343
+        # We need to get the total playlists first
+        playlist = self.get_saved_tracks_info(limit=UPPER_LIMIT)
+        total_count: int = playlist["data"]["me"]["library"]["tracks"]["totalCount"]
+
+        yield playlist["data"]["me"]["library"]["tracks"]
+
+        if total_count <= UPPER_LIMIT:
+            return
+
+        offset = UPPER_LIMIT
+        while offset < total_count:
+            yield self.get_saved_tracks_info(limit=UPPER_LIMIT, offset=offset)["data"]["me"]["library"]["tracks"]
+            offset += UPPER_LIMIT
+
     def _stage_create_playlist(self, name: str) -> str:
         url = "https://spclient.wg.spotify.com/playlist/v2/playlist"
         payload = {


### PR DESCRIPTION
* spotapi/playlist.py: added  `get_saved_tracks_info` and `paginate_saved_tracks` in `PrivatePlaylist`, which works the same way as `get_playlist_info`, and the corresponding pagination function. The function fetches information about the logged in user's Liked Songs, in the same way as PublicPlaylist does.