### PR TITLE
feat: add Artist.get_artist_discography and paginate_artist_discography

### DIFF
--- a/docs/artist.md
+++ b/docs/artist.md
@@ -66,6 +66,34 @@ Generates artist data in chunks.
   
 - **Yields:** A generator of artist data chunks.
 
+### `get_artist_discography(self, artist_id: str, /, *, section: Literal["all", "albums", "singles", "compilations"] = "all", offset: int = 0, limit: int = 50, order: Literal["DATE_DESC", "DATE_ASC"] = "DATE_DESC") -> Mapping[str, Any]`
+Fetches an artist's discography (releases) with pagination. Unlike `get_artist` (which uses `queryArtistOverview` and caps each section at ~10 items), this method targets the dedicated discography operations that support proper `offset`/`limit`/`order`.
+
+- **Parameters:**
+  - `artist_id`: The Spotify artist ID. Both raw IDs and URIs (`artist:xxxxx` or `spotify:artist:xxxxx`) are accepted.
+  - `section`: Which release group to fetch.
+    - `"all"` (default): merged albums + singles + compilations sorted by date.
+    - `"albums"` / `"singles"` / `"compilations"`: only that release type.
+  - `offset`: Pagination offset (default `0`).
+  - `limit`: Items per page (default `50`).
+  - `order`: Sort order — `"DATE_DESC"` (newest first, default) or `"DATE_ASC"`.
+
+- **Returns:** A mapping containing the discography page. Items live under `data.artistUnion.discography.<section>.items` with the section's `totalCount`.
+
+- **Note:** The API does not enforce a strict cap on `limit`; values up to 1000+ have been observed to work. The default of 50 mirrors `paginate_artist_discography`'s page size.
+
+### `paginate_artist_discography(self, artist_id: str, /, *, section: Literal["all", "albums", "singles", "compilations"] = "all", order: Literal["DATE_DESC", "DATE_ASC"] = "DATE_DESC") -> Generator[Mapping[str, Any], None, None]`
+Generates an artist's discography in chunks of 50 items per page until `totalCount` is reached.
+
+- **Parameters:**
+  - `artist_id`: The Spotify artist ID (raw ID or URI).
+  - `section`: Same as `get_artist_discography`.
+  - `order`: Same as `get_artist_discography`.
+
+- **Yields:** Lists of release items per page. Each item carries a nested `releases.items[*]` with the actual release `id`, `name`, `date`, `type`, `coverArt`, etc.
+
+- **Note:** If the section's total count is ≤ 50, only one page is yielded.
+
 ### `follow(self, artist_id: str, /) -> None`
 Follows an artist on Spotify.
 

--- a/spotapi/_tests/features/artist_test.py
+++ b/spotapi/_tests/features/artist_test.py
@@ -57,6 +57,107 @@ def test_paginate_artists():
         assert isinstance(chunk, list)
 
 
+# BTS — has plenty of albums + singles for paging assertions.
+_DISCOGRAPHY_ARTIST_ID = "3Nrfpe0tUJi4K4DXYWgMUX"
+
+
+def _assert_discography_section(response, section):
+    """Common shape check for queryArtistDiscography* responses."""
+    assert "data" in response
+    artist_union = response["data"]["artistUnion"]
+    assert artist_union["__typename"] == "Artist"
+    assert "discography" in artist_union
+    section_data = artist_union["discography"][section]
+    assert "items" in section_data
+    assert isinstance(section_data["items"], list)
+    assert "totalCount" in section_data
+
+
+def test_get_artist_discography_all():
+    """Section 'all' returns combined releases sorted by date."""
+    artist_instance = Artist()
+    response = artist_instance.get_artist_discography(
+        _DISCOGRAPHY_ARTIST_ID, section="all", limit=5
+    )
+    _assert_discography_section(response, "all")
+    items = response["data"]["artistUnion"]["discography"]["all"]["items"]
+    assert 0 < len(items) <= 5
+
+
+def test_get_artist_discography_albums():
+    """Section 'albums' returns album-type releases only."""
+    artist_instance = Artist()
+    response = artist_instance.get_artist_discography(
+        _DISCOGRAPHY_ARTIST_ID, section="albums", limit=5
+    )
+    _assert_discography_section(response, "albums")
+
+
+def test_get_artist_discography_singles():
+    """Section 'singles' returns single-type releases only."""
+    artist_instance = Artist()
+    response = artist_instance.get_artist_discography(
+        _DISCOGRAPHY_ARTIST_ID, section="singles", limit=5
+    )
+    _assert_discography_section(response, "singles")
+
+
+def test_get_artist_discography_with_uri():
+    """Accepts both raw IDs and spotify:artist:* URIs."""
+    artist_instance = Artist()
+    response = artist_instance.get_artist_discography(
+        f"spotify:artist:{_DISCOGRAPHY_ARTIST_ID}", section="all", limit=3
+    )
+    _assert_discography_section(response, "all")
+
+
+def test_get_artist_discography_offset():
+    """Advancing offset returns a different page of items than offset=0."""
+    artist_instance = Artist()
+    first = artist_instance.get_artist_discography(
+        _DISCOGRAPHY_ARTIST_ID, section="all", offset=0, limit=5
+    )["data"]["artistUnion"]["discography"]["all"]["items"]
+    second = artist_instance.get_artist_discography(
+        _DISCOGRAPHY_ARTIST_ID, section="all", offset=5, limit=5
+    )["data"]["artistUnion"]["discography"]["all"]["items"]
+    if len(first) >= 5 and len(second) > 0:
+        first_ids = {item.get("releases", {}).get("items", [{}])[0].get("id") for item in first}
+        second_ids = {item.get("releases", {}).get("items", [{}])[0].get("id") for item in second}
+        assert first_ids != second_ids
+
+
+def test_paginate_artist_discography():
+    """Generator yields lists summing up to totalCount."""
+    artist_instance = Artist()
+    first = artist_instance.get_artist_discography(
+        _DISCOGRAPHY_ARTIST_ID, section="singles", limit=1
+    )
+    total = first["data"]["artistUnion"]["discography"]["singles"]["totalCount"]
+
+    pages = list(artist_instance.paginate_artist_discography(
+        _DISCOGRAPHY_ARTIST_ID, section="singles"
+    ))
+    assert all(isinstance(chunk, list) for chunk in pages)
+    assert sum(len(chunk) for chunk in pages) == total
+
+
+def test_paginate_artist_discography_order_asc():
+    """order=DATE_ASC yields oldest-first."""
+    artist_instance = Artist()
+    pages = list(artist_instance.paginate_artist_discography(
+        _DISCOGRAPHY_ARTIST_ID, section="albums", order="DATE_ASC"
+    ))
+    assert len(pages) > 0
+    # First release in the earliest page should be no later than the last release
+    # in the final page when ordered ascending.
+    first_release = pages[0][0]["releases"]["items"][0]
+    last_release = pages[-1][-1]["releases"]["items"][0]
+    first_year = first_release.get("date", {}).get("year")
+    last_year = last_release.get("date", {}).get("year")
+    if first_year and last_year:
+        assert first_year <= last_year
+
+
 def test_follow_artist():
     """Test the follow method to follow an artist."""
     artist_id = "3TVXtAsR1Inumwj472S9r4"

--- a/spotapi/artist.py
+++ b/spotapi/artist.py
@@ -145,6 +145,112 @@ class Artist:
             ]["artists"]["items"]
             offset += UPPER_LIMIT
 
+    def get_artist_discography(
+        self,
+        artist_id: str,
+        /,
+        *,
+        section: Literal["all", "albums", "singles", "compilations"] = "all",
+        offset: int = 0,
+        limit: int = 50,
+        order: Literal["DATE_DESC", "DATE_ASC"] = "DATE_DESC",
+    ) -> Mapping[str, Any]:
+        """Gets an artist's discography with pagination.
+
+        Unlike queryArtistOverview (capped per section), the discography operations
+        support proper offset/limit/order. Section 'all' merges albums + singles +
+        compilations sorted by date.
+        """
+        if "artist:" in artist_id:
+            artist_id = artist_id.split("artist:")[-1]
+
+        operation_name = {
+            "all": "queryArtistDiscographyAll",
+            "albums": "queryArtistDiscographyAlbums",
+            "singles": "queryArtistDiscographySingles",
+            "compilations": "queryArtistDiscographyCompilations",
+        }[section]
+        url = "https://api-partner.spotify.com/pathfinder/v2/query"
+        payload = {
+            "variables": {
+                "uri": f"spotify:artist:{artist_id}",
+                "offset": offset,
+                "limit": limit,
+                "order": order,
+            },
+            "operationName": operation_name,
+            "extensions": {
+                "persistedQuery": {
+                    "version": 1,
+                    "sha256Hash": self.base.part_hash(operation_name),
+                },
+            },
+        }
+
+        resp = self.base.client.post(url, json=payload, authenticate=True)
+
+        if resp.fail:
+            raise ArtistError(
+                "Could not get artist discography", error=resp.error.string
+            )
+
+        if not isinstance(resp.response, Mapping):
+            raise ArtistError("Invalid JSON response")
+
+        return resp.response
+
+    def paginate_artist_discography(
+        self,
+        artist_id: str,
+        /,
+        *,
+        section: Literal["all", "albums", "singles", "compilations"] = "all",
+        order: Literal["DATE_DESC", "DATE_ASC"] = "DATE_DESC",
+    ) -> Generator[Mapping[str, Any], None, None]:
+        """Generator that fetches an artist's discography in chunks.
+
+        Note: If total_count <= 50, then there is no need to paginate.
+        """
+        UPPER_LIMIT: int = 50
+
+        first = self.get_artist_discography(
+            artist_id, section=section, offset=0, limit=UPPER_LIMIT, order=order
+        )
+        section_data = (
+            first.get("data", {})
+            .get("artistUnion", {})
+            .get("discography", {})
+            .get(section, {})
+        )
+        items = section_data.get("items") or []
+        total_count: int = section_data.get("totalCount") or len(items)
+
+        yield items
+
+        if total_count <= UPPER_LIMIT:
+            return
+
+        offset = UPPER_LIMIT
+        while offset < total_count:
+            resp = self.get_artist_discography(
+                artist_id,
+                section=section,
+                offset=offset,
+                limit=UPPER_LIMIT,
+                order=order,
+            )
+            page_items = (
+                resp.get("data", {})
+                .get("artistUnion", {})
+                .get("discography", {})
+                .get(section, {})
+                .get("items")
+            ) or []
+            if not page_items:
+                break
+            yield page_items
+            offset += UPPER_LIMIT
+
     def _do_follow(
         self,
         artist_id: str,


### PR DESCRIPTION
## Summary

Adds `Artist.get_artist_discography` and `Artist.paginate_artist_discography` so callers can enumerate an artist's full release catalog. Previously the only artist-page entry point was `get_artist` (backed by `queryArtistOverview`), which caps each release section (albums/singles/compilations) at ~10 items per response and has no pagination — making it unusable for crawlers or any caller that needs a complete discography.

## What changed

- **`get_artist_discography(artist_id, *, section, offset, limit, order)`** — single-page fetch backed by the dedicated discography operations (`queryArtistDiscographyAll/Albums/Singles/Compilations`). These accept proper `offset`/`limit`/`order` arguments, unlike the overview query.
  - `section` is a `Literal["all", "albums", "singles", "compilations"]`. `"all"` returns the merged date-sorted feed (same set the web client shows on an artist page); the others scope to a single release type.
  - `order` is `"DATE_DESC"` (default) or `"DATE_ASC"`.
  - Mirrors the existing `get_artist` shape (positional-only `artist_id`, keyword-only options, accepts both raw IDs and `spotify:artist:*` URIs).
- **`paginate_artist_discography(artist_id, *, section, order)`** — generator that pages through the section at 50 items per page until `totalCount`, matching the existing `paginate_*` pattern (`paginate_artists`, `paginate_album`, `paginate_playlist`, `paginate_songs`, `paginate_podcast`).

## Backward compatibility

Purely additive. No existing method signatures or behaviors change. `get_artist` is untouched.

## Verification

Tested against live Spotify with multiple discography sizes:

- **Small** — Taylor Swift (`06HL4z0CvFAxyc27GXpf02`): `all=116`, `albums=33`, `singles=82`, `compilations=1`. Single-page calls + multi-page pagination both return exact counts.
- **Medium** — BTS (`3Nrfpe0tUJi4K4DXYWgMUX`): `all=84`, `singles=59` — verified the generator yields multiple pages summing to `totalCount`.
- **Large** — Mozart (`4NJhFmfw43RLBLjQvxDuRS`): `all=1760`. Confirmed the API has no practical `limit` cap (limits up to `5000` returned data without errors, capping naturally at `totalCount`).
- **Section equivalence** — `section='all'` items carry a `releases.items[*].type` field of `ALBUM`/`SINGLE`/`COMPILATION`, matching what the per-section operations return.

## Test plan

- [x] `spotapi/_tests/features/artist_test.py` — 7 new cases:
  - `test_get_artist_discography_all` / `_albums` / `_singles` — shape + non-empty assertions per section
  - `test_get_artist_discography_with_uri` — accepts `spotify:artist:*` URI
  - `test_get_artist_discography_offset` — `offset=0` and `offset=5` return disjoint pages
  - `test_paginate_artist_discography` — generator output sums to `totalCount`
  - `test_paginate_artist_discography_order_asc` — `DATE_ASC` yields oldest-first
- [x] `docs/artist.md` updated with both method signatures and parameter docs
