### PR TITLE
Replace `tls_client` with `curl_cffi`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ colorama==0.4.6
 Pillow==10.4.0
 readerwriterlock==1.0.9
 requests==2.31.0
-tls_client==1.0
+curl_cffi==0.15.0
 typing_extensions==4.12.2
 validators==0.33.0
 websockets==12.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ __install_require__ = [
     "colorama",
     "Pillow",
     "readerwriterlock",
-    "tls_client",
+    "curl_cffi",
     "typing_extensions",
     "validators",
     "pyotp",

--- a/spotapi/album.py
+++ b/spotapi/album.py
@@ -33,7 +33,7 @@ class PublicAlbum:
         album: str,
         /,
         *,
-        client: TLSClient = TLSClient("chrome_120", "", auto_retries=3),
+        client: TLSClient = TLSClient("chrome120", "", auto_retries=3),
         language: str = "en",
     ) -> None:
         self.base = BaseClient(client=client, language=language)

--- a/spotapi/artist.py
+++ b/spotapi/artist.py
@@ -37,7 +37,7 @@ class Artist:
         self,
         login: Login | None = None,
         *,
-        client: TLSClient = TLSClient("chrome_120", "", auto_retries=3),
+        client: TLSClient = TLSClient("chrome120", "", auto_retries=3),
         language: str = "en",
     ) -> None:
         if login and not login.logged_in:

--- a/spotapi/client.py
+++ b/spotapi/client.py
@@ -1,3 +1,4 @@
+import re
 import time
 import json
 import base64
@@ -93,7 +94,8 @@ class BaseClient:
         self.client.authenticate = lambda kwargs: self._auth_rule(kwargs)
         self.client.on_auth_failure = lambda resp: self._handle_auth_failure(resp)
 
-        self.browser_version = self.client.client_identifier.split("_")[1]
+        match = re.search(r"\d+", self.client.impersonate)
+        self.browser_version = match.group()
         self.client.headers.update(
             {
                 "Content-Type": "application/json;charset=UTF-8",

--- a/spotapi/http/data.py
+++ b/spotapi/http/data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Union
 from requests import Response as StdResponse
-from tls_client.response import Response as TLSResponse
+from curl_cffi.requests import Response as TLSResponse
 
 __all__ = ["Response", "Error", "StdResponse", "TLSResponse"]
 

--- a/spotapi/http/request.py
+++ b/spotapi/http/request.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Type, Dict
-from tls_client.settings import ClientIdentifiers
-from tls_client.exceptions import TLSClientExeption
-from tls_client.response import Response as TLSResponse
-from spotapi.exceptions import ParentException, RequestError
-from spotapi.http.data import Response
-from tls_client import Session
-import requests
 import atexit
 import json
+from typing import Any, Callable, Dict, Type
+
+import requests
+from curl_cffi.requests import Response as TLSResponse
+from curl_cffi.requests import Session
+from curl_cffi.requests.exceptions import RequestException
+
+from spotapi.exceptions import ParentException, RequestError
+from spotapi.http.data import Response
+
+ClientIdentifiers = str
 
 __all__ = [
     "StdClient",
@@ -110,7 +113,7 @@ class StdClient:
 
 class TLSClient(Session):
     """
-    TLS-HTTP Client implementation wrapped around the tls_client library.
+    TLS-HTTP Client implementation wrapped around the curl_cffi library.
 
     This is fully undetected by Spotify.com.
     """
@@ -123,11 +126,12 @@ class TLSClient(Session):
         auto_retries: int = 0,
         auth_rule: Callable[[Dict[Any, Any]], Dict[Any, Any]] | None = None,
     ) -> None:
-        super().__init__(client_identifier=profile, random_tls_extension_order=True)
+        super().__init__(impersonate=profile)
 
         if proxy:
             self.proxies = {"http": f"http://{proxy}", "https": f"http://{proxy}"}
 
+        self.client_identifier = profile
         self.auto_retries = auto_retries + 1
         self.authenticate = auth_rule
         self.on_auth_failure: Callable[[Response], bool] | None = None
@@ -150,8 +154,8 @@ class TLSClient(Session):
         err = "Unknown"
         for _ in range(self.auto_retries):
             try:
-                response = self.execute_request(method.upper(), url, **kwargs)
-            except TLSClientExeption as e:
+                response = self.request(method.upper(), url, **kwargs)
+            except RequestException as e:
                 err = str(e)
                 continue
             else:
@@ -181,9 +185,6 @@ class TLSClient(Session):
         if not body:
             body = None
 
-        # Why is status_code a None type...
-        assert response.status_code is not None, "Status Code is None"
-
         resp = Response(
             status_code=int(response.status_code), response=body, raw=response
         )
@@ -210,7 +211,7 @@ class TLSClient(Session):
 
         response = self.build_request(method, url, allow_redirects=True, **kwargs)
         if response is None:
-            raise TLSClientExeption("Request kept failing after retries.")
+            raise RequestError("Request kept failing after retries.")
 
         parsed = self.parse_response(response, method, False)
 
@@ -224,7 +225,7 @@ class TLSClient(Session):
             kwargs = self.authenticate(kwargs)
             response = self.build_request(method, url, allow_redirects=True, **kwargs)
             if response is None:
-                raise TLSClientExeption("Request kept failing after retries.")
+                raise RequestError("Request kept failing after retries.")
             parsed = self.parse_response(response, method, False)
 
         if danger and self.fail_exception and parsed.fail:

--- a/spotapi/http/request.py
+++ b/spotapi/http/request.py
@@ -131,7 +131,6 @@ class TLSClient(Session):
         if proxy:
             self.proxies = {"http": f"http://{proxy}", "https": f"http://{proxy}"}
 
-        self.client_identifier = profile
         self.auto_retries = auto_retries + 1
         self.authenticate = auth_rule
         self.on_auth_failure: Callable[[Response], bool] | None = None

--- a/spotapi/playlist.py
+++ b/spotapi/playlist.py
@@ -38,7 +38,7 @@ class PublicPlaylist:
         playlist: str,
         /,
         *,
-        client: TLSClient = TLSClient("chrome_120", "", auto_retries=3),
+        client: TLSClient = TLSClient("chrome120", "", auto_retries=3),
         language: str = "en",
     ) -> None:
         self.base = BaseClient(client=client, language=language)

--- a/spotapi/podcast.py
+++ b/spotapi/podcast.py
@@ -32,7 +32,7 @@ class Podcast:
         self,
         podcast: str | None = None,
         *,
-        client: TLSClient = TLSClient("chrome_120", "", auto_retries=3),
+        client: TLSClient = TLSClient("chrome120", "", auto_retries=3),
         language: str = "en",
     ) -> None:
         self.base = BaseClient(client=client, language=language)

--- a/spotapi/public.py
+++ b/spotapi/public.py
@@ -44,7 +44,7 @@ class Pooler(Generic[T]):
 
 
 client_pool: Pooler[TLSClient] = Pooler(
-    factory=lambda: TLSClient("chrome_120", "", auto_retries=3)
+    factory=lambda: TLSClient("chrome120", "", auto_retries=3)
 )
 GeneratorType: TypeAlias = Generator[Mapping[str, Any], None, None]
 

--- a/spotapi/song.py
+++ b/spotapi/song.py
@@ -31,7 +31,7 @@ class Song:
         self,
         playlist: PrivatePlaylist | None = None,
         *,
-        client: TLSClient = TLSClient("chrome_120", "", auto_retries=3),
+        client: TLSClient = TLSClient("chrome120", "", auto_retries=3),
         language: str = "en",
     ) -> None:
         self.playlist = playlist

--- a/spotapi/types/data.py
+++ b/spotapi/types/data.py
@@ -30,7 +30,7 @@ __all__ = [
 class Config:
     logger: LoggerProtocol
     solver: CaptchaProtocol | None = field(default=None)
-    client: TLSClient = field(default=TLSClient("chrome_120", "", auto_retries=3))
+    client: TLSClient = field(default=TLSClient("chrome120", "", auto_retries=3))
 
     def __str__(self) -> str:
         return "Config()"


### PR DESCRIPTION
Use `curl_cffi` for TLS impersonation to keep lib usage in `musl`/`Alpine` environment, beucase `tls_client` cannot run on `musl`/`Alpine`.

`tls_client` can't be patched around without replacing the native library:
- `tls-client` release ships only a `py3-none-any` wheel (no
  `musllinux` wheel was ever published). The Go shared libraries are bundled inside a
  "pure-Python" wheel, so pip's platform resolution can't select a correct build.
- [`tls_client/cffi.py`](https://github.com/FlorianREGAZ/Python-Tls-Client/blob/master/tls_client/cffi.py).`x86_64` always loads `tls-client-x86.so`, which is `glibc`. A `musl`-linked binary (`tls-client-amd64.so`) is bundled but is never selected.
- even force-loading the bundled `-amd64.so` on `Alpine` fails at
  relocation (`initial-exec TLS resolves to dynamic definition`) - the known Go
  `c-shared`-on-musl `dlopen` incompatibility. So fixing the loader wouldn't rescue it.
  
Maybe there way to fix `https://github.com/FlorianREGAZ/Python-Tls-Client`, but it's unsupported now. I don't see reason to use it now when we have `curl_cffi`.


